### PR TITLE
Feature/responsive video player cleanup

### DIFF
--- a/web/app/animations/page.tsx
+++ b/web/app/animations/page.tsx
@@ -112,6 +112,7 @@ export default function Animations() {
                 thumbnailCid={selectedAsset.thumbnailCid}
                 mimeType={selectedAsset.mimeType}
                 fileName={selectedAsset.fileName}
+                renditions={(selectedAsset.metadata as any)?.renditions}
                 title={selectedAsset.name}
                 className="w-full h-96 md:h-[500px] lg:h-[600px]"
               />

--- a/web/app/animations/page.tsx
+++ b/web/app/animations/page.tsx
@@ -43,19 +43,18 @@ export default function Animations() {
   const loadAssets = async () => {
     try {
       const data = await dataManager.getData('assets');
-      console.log('🔍 Raw assets data:', data);
-      
+      // Raw assets data is available in `data`.
       // Filter for approved video/animation assets
       const animations = data.filter(asset => {
         const isApproved = asset.status === 'approved';
         const isAnimation = asset.type === 'animation' || asset.type === 'video' || asset.mimeType?.startsWith('video/');
-        
-        console.log(`Asset "${asset.name}": status=${asset.status}, type=${asset.type}, mimeType=${asset.mimeType}, approved=${isApproved}, isAnimation=${isAnimation}`);
-        
         return isApproved && isAnimation;
       });
-      
-      console.log('🎬 Filtered animations:', animations);
+      // In debug mode you can inspect animations; otherwise avoid noisy logs
+      if (process.env.NEXT_PUBLIC_DEBUG === 'true') {
+        // eslint-disable-next-line no-console
+        console.log('🎬 Filtered animations:', animations);
+      }
       setAssets(animations);
       if (animations.length > 0) {
         setSelectedAsset(animations[0]);


### PR DESCRIPTION
Body:

Summary
Make the holographic animation player friendly to small screens and low-bandwidth clients, reduce visual overhead on mobile, and remove noisy debug logs from production.

What changed
HolographicVideoPlayer.tsx
Use responsive sizing (aspect-ratio + max-height/min-height) instead of fixed large heights.
Add renditions prop and client-side selection logic (choose low-res on small screens).
Lazy-load the <source> with an IntersectionObserver so off-screen players don't buffer.
Reduce holographic rings/particles and drop-shadow intensity on small screens.
Gate verbose debug logs behind NEXT_PUBLIC_DEBUG=true.
page.tsx
Pass selectedAsset.metadata?.renditions to the player (cast safely to avoid TS breakage).
Remove noisy per-asset logs; keep gated logging for debug.
Why
Users reported long buffering and oversized video frames that force scrolling on small screens. These changes:

Prevent off-screen videos from consuming bandwidth until visible.
Let mobile clients pick smaller renditions (when available) to improve time-to-first-frame.
Keep the UI compact on small viewports and reduce rendering overhead from heavy visuals.
Clean up console noise in production.
MCP / metadata notes
The player supports an optional renditions array in asset metadata:
Example shape: { cid: string, width?: number, height?: number, bitrate?: number, label?: string }.
Recommended MCP responsibilities (follow-up):
Pin and expose rendition CIDs in metadata.renditions on ingest.
Validate file headers (Content-Type and Accept-Ranges) for pinned CIDs.
Optionally generate and store 360p/480p/720p renditions during upload processing.
How to test (QA checklist)
 Layout: On mobile/narrow viewport the player fits without forcing vertical scroll (respects aspect ratio and max height).
 Lazy-load: Off-screen player does not initiate video network requests until scrolled into view (check Network tab).
 Rendition selection: If metadata.renditions exists for an asset, narrow viewports select a lower-res CID and wide viewports pick a higher-res CID.
 Debug gating: Console is free of debug spam unless NEXT_PUBLIC_DEBUG=true.
 Streaming: Confirm player uses per-asset fileCid (not the root index CID) — request headers should include Accept-Ranges and Access-Control-Allow-Origin.
Files changed (high level)
HolographicVideoPlayer.tsx — responsive, lazy-load, renditions, debug gating
page.tsx — pass renditions, reduce logs
Follow-ups (optional)
Add an on-player UI to switch renditions manually for QA.
Implement MCP ingestion checks to pin and validate rendition CIDs and store renditions automatically.
Consider automated transcoding / HLS generation for best streaming experience.
Suggested reviewers
@prooftv (owner)
frontend/ux or anyone familiar with Holographic UI
PR branch (already pushed):
feature/responsive-video-player-cleanup
Create PR URL:
https://github.com/prooftv/themightyverse/pull/new/feature/responsive-video-player-cleanup

If you want, I can now:

Draft a one-paragraph PR summary for the first comment on merge (short).
Add a tiny toggle in the player to manually switch renditions (useful for QA).
Tell me which and I’ll prepare it.
GPT-5 mini • 0.9x